### PR TITLE
Wind the site down into an archive

### DIFF
--- a/src/md/hotline.md
+++ b/src/md/hotline.md
@@ -1,5 +1,7 @@
 # NCH Community Hotline
 
+> **This hotline has been retired.** The North Crown Hill community hotline operated during the COVID-19 pandemic. The phone number is no longer active and calls are no longer answered. The description below is kept for the historical record &mdash; and the crisis resources further down may still be helpful to you today.
+
 Your neighbors are here for you! The NCH community hotline is a telephone number for requesting assistance with whatever needs or questions you may have. Any resident of North Crown Hill may call and leave a message at any time - though we're especially excited that we now have a way to connect and support our neighbors who don't have the access or inclination to use the internet.
 
 ## Calling
@@ -20,12 +22,12 @@ In addition to 911, here are some other helpful numbers you might consider if yo
 * [Sexual Assault Hotline](https://www.rainn.org/about-national-sexual-assault-telephone-hotline): [800-656-4673](tel:800-656-4673)
 * [Domestic Violence Hotline](https://www.thehotline.org/): [800-799-7233](tel:800-799-7233)
 * [King County Crisis Clinic](https://www.crisisconnections.org/): [866-427-4747](tel:866-427-4747)
-* [National Suicide Prevention Lifeline](https://suicidepreventionlifeline.org/): [800-273-8255](tel:800-273-8255)
+* [988 Suicide & Crisis Lifeline](https://988lifeline.org/): [988](tel:988)
 * [Substance Abuse & Mental Health Hotline](https://www.samhsa.gov/find-help/national-helpline): [800-662-4357](tel:800-662-4357)
 * [Trans Lifeline](https://www.translifeline.org/): [877-565-8860](tel:877-565-8860)
  
 &nbsp;
 
 ## Volunteering
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSd3-Or3KJbjH-6NajRuyFkrIOEUK3QcPfF8vsM0D38_62DszQ/viewform?embedded=true"
-        title="NCH Volunteer Signup Form" width="640" height="1050" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+
+_Volunteer signups are now closed. Thank you to every neighbor who answered a call._

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,6 +12,22 @@ export default () => (
     <div className="splash-container">
       <div className="splash">
         <StaticImage src="../images/nchlogo.jpg" alt="NCH logo" layout="fixed" width={200} height={200} style={{ display: "inline-block" }} />
+        <p style={{
+          background: "rgba(255,255,255,0.85)",
+          color: "#333",
+          padding: "0.75em 1.25em",
+          borderRadius: "8px",
+          margin: "1em auto",
+          maxWidth: "620px",
+          fontSize: "0.95em",
+          lineHeight: "1.45em",
+        }}>
+          <strong>Archive.</strong> North Crown Hill was a neighbor-to-neighbor
+          mutual aid network formed in March 2020 during the COVID-19 pandemic.
+          Active operations have since wound down &mdash; the newsletter, chat,
+          and hotline are no longer staffed. This site remains as an archive of
+          what we built together. Thank you, neighbors. &mdash;James
+        </p>
         <h1>
           Building links of human connection
           <br />

--- a/src/pages/join.js
+++ b/src/pages/join.js
@@ -7,13 +7,13 @@ export default ({ data }) => (
   <Layout>
     <div class="content">
       <h1>Join</h1>
-      <p>If you a a resident within the North Crown Hill <Link to="/who/">boundaries</Link>, you can join us! Just submit the form below, 
-        and then wait a day or two to receive a welcome email. If you don't hear back within 72 hours, or have any 
-        questions at all, feel free to email <a href="mailto:north.crown.hill@gmail.com">north.crown.hill@gmail.com</a>
-      </p>
-      <p>If you don't have an email address, enter your phone number instead, and you'll get a call with our hotline number.</p>
-      <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSc0XX0C9AmW6jObL_pOjR8lNXa8cpkWdXPXBseBBKeVfs5XaQ/viewform?embedded=true"
-        title="NCH Signup Form" width="640" height="700" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+      <p>North Crown Hill is no longer accepting new members &mdash; the network's
+        active phase wound down after 2020, and the newsletter, chat, and hotline
+        are no longer staffed. This page remains as part of the site archive.</p>
+      <p>Curious what it was? See <Link to="/what/">what we did</Link>, browse the
+        past <Link to="/newsletter/">newsletters</Link>, or read the
+        <Link to="/about/"> story behind the project</Link>. For anything else,
+        you can still reach <a href="mailto:north.crown.hill@gmail.com">north.crown.hill@gmail.com</a>.</p>
       <p>&nbsp;</p>
     </div>
     <Footer />


### PR DESCRIPTION
Now that the Twilio hotline number is off, this reframes the live-sounding pages so the site reads honestly as an **archive** — without rewriting the original 2020 period-voice content (that's the historical record).

### Changes
- **Home:** short *"Archive — North Crown Hill was a mutual aid network formed in March 2020 … thank you, neighbors. —James"* banner above the splash.
- **Hotline:** a "this hotline has been retired / number no longer works" notice at the top. Kept the crisis-resource list (still genuinely useful) and updated the old Suicide Prevention Lifeline `800-273-8255` → the current **988 Suicide & Crisis Lifeline**. Removed the volunteer signup form.
- **Join:** replaced the embedded Google signup form with an archive note linking to what / newsletter / about.

### Please review the wording
This is a public farewell in your voice — **please read the banner text on the deploy preview and tweak anything before merging.** I left it unmerged on purpose.

### Still on your plate (account-side)
- Set both **Google Forms** (join + volunteer) to stop accepting responses.
- **Twilio:** release the number fully (not just disabled) so it stops billing; close the account if unused.
- **Mailchimp / Slack:** export records, optional farewell, then downgrade/close.
- **Delete the `nch-functions` Netlify site** (its repo is now archived).
- Keep renewing **northcrownhill.com** to keep this archive online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)